### PR TITLE
Add nodeSelector to values.yaml

### DIFF
--- a/templates/flask.yaml
+++ b/templates/flask.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: flask
     spec:
+      nodeSelector: {{- toYaml .Values.flask.nodeSelector | nindent 8 }}
       securityContext:
         runAsUser: 0
         runAsGroup: 0

--- a/templates/flask.yaml
+++ b/templates/flask.yaml
@@ -20,7 +20,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: flask
     spec:
-      nodeSelector: {{- toYaml .Values.flask.nodeSelector | nindent 8 }}
+      {{- with .Values.flask.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsUser: 0
         runAsGroup: 0

--- a/templates/flask.yaml
+++ b/templates/flask.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       {{- with .Values.flask.nodeSelector }}
       nodeSelector:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
         runAsUser: 0

--- a/templates/postgres.yaml
+++ b/templates/postgres.yaml
@@ -22,6 +22,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: postgres
     spec:
+      nodeSelector: {{- toYaml .Values.postgres.nodeSelector | nindent 8 }}
       containers:
         - name: postgres
           image: "{{ .Values.postgres.image }}"

--- a/templates/postgres.yaml
+++ b/templates/postgres.yaml
@@ -22,7 +22,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: postgres
     spec:
-      nodeSelector: {{- toYaml .Values.postgres.nodeSelector | nindent 8 }}
+      {{- with .Values.postgres.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: postgres
           image: "{{ .Values.postgres.image }}"

--- a/templates/postgres.yaml
+++ b/templates/postgres.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       {{- with .Values.postgres.nodeSelector }}
       nodeSelector:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: postgres

--- a/templates/redis.yaml
+++ b/templates/redis.yaml
@@ -22,6 +22,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: redis
     spec:
+      nodeSelector: {{- toYaml .Values.redis.nodeSelector | nindent 8 }}
       containers:
         - name: redis
           image: "{{ .Values.redis.image }}"

--- a/templates/redis.yaml
+++ b/templates/redis.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       {{- with .Values.redis.nodeSelector }}
       nodeSelector:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: redis

--- a/templates/redis.yaml
+++ b/templates/redis.yaml
@@ -22,7 +22,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: redis
     spec:
-      nodeSelector: {{- toYaml .Values.redis.nodeSelector | nindent 8 }}
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: redis
           image: "{{ .Values.redis.image }}"

--- a/templates/worker.yaml
+++ b/templates/worker.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: worker
     spec:
+      nodeSelector: {{- toYaml .Values.worker.nodeSelector | nindent 8 }}
       securityContext:
         runAsUser: 0
         runAsGroup: 0

--- a/templates/worker.yaml
+++ b/templates/worker.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       {{- with .Values.worker.nodeSelector }}
       nodeSelector:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
         runAsUser: 0

--- a/templates/worker.yaml
+++ b/templates/worker.yaml
@@ -20,7 +20,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: worker
     spec:
-      nodeSelector: {{- toYaml .Values.worker.nodeSelector | nindent 8 }}
+      {{- with .Values.worker.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsUser: 0
         runAsGroup: 0


### PR DESCRIPTION
👋 I've added `nodeSelector` to the `values.yaml` so I can target specific machines (my k3s cluster is a mix of pi's and NUCs). This is quite a niche feature, so I've left it out of the default values, and I've tested both with and without any values present.

Preview of the changes:
```
$ helm template my-audiomuse . | grep -A 1 nodeSelector 
      nodeSelector:
        arch: amd64
--
      nodeSelector:
        arch: amd64
--
      nodeSelector:
        arch: amd64
--
      nodeSelector:
        arch: amd64
```
Dry run on client:
```
$ helm template my-audiomuse . | kubectl apply --dry-run=client -f - 
secret/my-audiomuse-audiomuse-ai-jellyfin created (dry run)
secret/my-audiomuse-audiomuse-ai-postgres created (dry run)
secret/my-audiomuse-audiomuse-ai-gemini created (dry run)
secret/my-audiomuse-audiomuse-ai-mistral created (dry run)
secret/my-audiomuse-audiomuse-ai-ai-chat-db created (dry run)
secret/my-audiomuse-audiomuse-ai-navidrome created (dry run)
secret/my-audiomuse-audiomuse-ai-lyrion created (dry run)
configmap/my-audiomuse-audiomuse-ai-env-vars created (dry run)
persistentvolumeclaim/my-audiomuse-audiomuse-ai-postgres-pvc created (dry run)
service/my-audiomuse-audiomuse-ai-flask-service created (dry run)
service/my-audiomuse-audiomuse-ai-postgres created (dry run)
service/my-audiomuse-audiomuse-ai-redis created (dry run)
deployment.apps/my-audiomuse-audiomuse-ai-flask created (dry run)
deployment.apps/my-audiomuse-audiomuse-ai-postgres created (dry run)
deployment.apps/my-audiomuse-audiomuse-ai-redis created (dry run)
deployment.apps/my-audiomuse-audiomuse-ai-worker created (dry run)
```
Dry run on server:
```
$ helm template my-audiomuse . | kubectl apply --dry-run=server -f - 
secret/my-audiomuse-audiomuse-ai-jellyfin created (server dry run)
secret/my-audiomuse-audiomuse-ai-postgres created (server dry run)
secret/my-audiomuse-audiomuse-ai-gemini created (server dry run)
secret/my-audiomuse-audiomuse-ai-mistral created (server dry run)
secret/my-audiomuse-audiomuse-ai-ai-chat-db created (server dry run)
secret/my-audiomuse-audiomuse-ai-navidrome created (server dry run)
secret/my-audiomuse-audiomuse-ai-lyrion created (server dry run)
configmap/my-audiomuse-audiomuse-ai-env-vars created (server dry run)
persistentvolumeclaim/my-audiomuse-audiomuse-ai-postgres-pvc created (server dry run)
service/my-audiomuse-audiomuse-ai-flask-service created (server dry run)
service/my-audiomuse-audiomuse-ai-postgres created (server dry run)
service/my-audiomuse-audiomuse-ai-redis created (server dry run)
deployment.apps/my-audiomuse-audiomuse-ai-flask created (server dry run)
deployment.apps/my-audiomuse-audiomuse-ai-postgres created (server dry run)
deployment.apps/my-audiomuse-audiomuse-ai-redis created (server dry run)
deployment.apps/my-audiomuse-audiomuse-ai-worker created (server dry run)
```