### PR TITLE
Add securityContext to values.yaml

### DIFF
--- a/templates/flask.yaml
+++ b/templates/flask.yaml
@@ -20,10 +20,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: flask
     spec:
+      {{- with .Values.flask.securityContext }}
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
-        fsGroup: 0
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: flask-app
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/templates/postgres.yaml
+++ b/templates/postgres.yaml
@@ -22,6 +22,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: postgres
     spec:
+      securityContext: {{- toYaml .Values.postgres.securityContext | nindent 8 }}
       containers:
         - name: postgres
           image: "{{ .Values.postgres.image }}"

--- a/templates/postgres.yaml
+++ b/templates/postgres.yaml
@@ -22,7 +22,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: postgres
     spec:
-      securityContext: {{- toYaml .Values.postgres.securityContext | nindent 8 }}
+      {{- with .Values.postgres.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: postgres
           image: "{{ .Values.postgres.image }}"

--- a/templates/redis.yaml
+++ b/templates/redis.yaml
@@ -22,6 +22,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: redis
     spec:
+      {{- with .Values.redis.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: redis
           image: "{{ .Values.redis.image }}"

--- a/templates/worker.yaml
+++ b/templates/worker.yaml
@@ -20,10 +20,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: worker
     spec:
+      {{- with .Values.worker.securityContext }}
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
-        fsGroup: 0
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: rq-worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/values.yaml
+++ b/values.yaml
@@ -16,12 +16,20 @@ image:
 
 flask:
   replicaCount: 1
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: 0
   service:
     type: LoadBalancer
     port: 8000
 
 worker:
   replicaCount: 3
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: 0
 
 redis:
   enabled: true


### PR DESCRIPTION
👋 I've added securityContext to the `postgres` section of values.yaml so I can get persistence working. The core issue is how postgres needs to `chown` its data directory on boot, however not all Kubernetes storage adapters allow the changing of permissions on mounted volumes - I'm using an NFS storage adapter with this limitation - the solution is to start the container with the userID matching the attached volume. This is quite a niche feature, so I've left it out of the default values, and I've tested both with and without any values present.

Preview of the changes:
```
$ helm template my-audiomuse . | grep -A 4 securityContext
...
--
      securityContext:
        fsGroup: 100
        runAsGroup: 100
        runAsUser: 1024
```

```
$ helm template my-audiomuse . | kubectl apply --dry-run=client -f - 
secret/my-audiomuse-audiomuse-ai-jellyfin created (dry run)
secret/my-audiomuse-audiomuse-ai-postgres created (dry run)
secret/my-audiomuse-audiomuse-ai-gemini created (dry run)
secret/my-audiomuse-audiomuse-ai-mistral created (dry run)
secret/my-audiomuse-audiomuse-ai-ai-chat-db created (dry run)
secret/my-audiomuse-audiomuse-ai-navidrome created (dry run)
secret/my-audiomuse-audiomuse-ai-lyrion created (dry run)
configmap/my-audiomuse-audiomuse-ai-env-vars created (dry run)
persistentvolumeclaim/my-audiomuse-audiomuse-ai-postgres-pvc created (dry run)
service/my-audiomuse-audiomuse-ai-flask-service created (dry run)
service/my-audiomuse-audiomuse-ai-postgres created (dry run)
service/my-audiomuse-audiomuse-ai-redis created (dry run)
deployment.apps/my-audiomuse-audiomuse-ai-flask created (dry run)
deployment.apps/my-audiomuse-audiomuse-ai-postgres created (dry run)
deployment.apps/my-audiomuse-audiomuse-ai-redis created (dry run)
deployment.apps/my-audiomuse-audiomuse-ai-worker created (dry run)
```

```
$ helm template my-audiomuse . | kubectl apply --dry-run=server -f - 
secret/my-audiomuse-audiomuse-ai-jellyfin created (server dry run)
secret/my-audiomuse-audiomuse-ai-postgres created (server dry run)
secret/my-audiomuse-audiomuse-ai-gemini created (server dry run)
secret/my-audiomuse-audiomuse-ai-mistral created (server dry run)
secret/my-audiomuse-audiomuse-ai-ai-chat-db created (server dry run)
secret/my-audiomuse-audiomuse-ai-navidrome created (server dry run)
secret/my-audiomuse-audiomuse-ai-lyrion created (server dry run)
configmap/my-audiomuse-audiomuse-ai-env-vars created (server dry run)
persistentvolumeclaim/my-audiomuse-audiomuse-ai-postgres-pvc created (server dry run)
service/my-audiomuse-audiomuse-ai-flask-service created (server dry run)
service/my-audiomuse-audiomuse-ai-postgres created (server dry run)
service/my-audiomuse-audiomuse-ai-redis created (server dry run)
deployment.apps/my-audiomuse-audiomuse-ai-flask created (server dry run)
deployment.apps/my-audiomuse-audiomuse-ai-postgres created (server dry run)
deployment.apps/my-audiomuse-audiomuse-ai-redis created (server dry run)
deployment.apps/my-audiomuse-audiomuse-ai-worker created (server dry run)
```