### PR TITLE
Add OpenAI parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ mistral:
 # You can use "OLLAMA", "GEMINI", "MISTRAL", or "NONE" (some features will be disabled if NONE)
 config:
   mediaServerType: "jellyfin"
-  aiModelProvider: "NONE" # Options: "GEMINI", "OLLAMA", "MISTRAL", or "NONE"
+  aiModelProvider: "NONE" # Options: "OPENAI", "GEMINI", "OLLAMA", "MISTRAL", or "NONE"
   ollamaServerUrl: "http://192.168.3.15:11434/api/generate"
   ollamaModelName: "mistral:7b"
   geminiModelName: "gemini-1.5-flash-latest"
@@ -87,7 +87,7 @@ mistral:
 # You can use "OLLAMA", "GEMINI", "MISTRAL", or "NONE" (some features will be disabled if NONE)
 config:
   mediaServerType: "navidrome"
-  aiModelProvider: "NONE" # Options: "GEMINI", "OLLAMA", "MISTRAL", or "NONE"
+  aiModelProvider: "NONE" # Options: "OPENAI", "GEMINI", "OLLAMA", "MISTRAL", or "NONE"
   ollamaServerUrl: "http://192.168.3.15:11434/api/generate"
   ollamaModelName: "mistral:7b"
   geminiModelName: "gemini-1.5-flash-latest"
@@ -120,7 +120,7 @@ mistral:
 # You can use "OLLAMA", "GEMINI", "MISTRAL", or "NONE" (some features will be disabled if NONE)
 config:
   mediaServerType: "lyrion"
-  aiModelProvider: "NONE" # Options: "GEMINI", "OLLAMA", "MISTRAL", or "NONE"
+  aiModelProvider: "NONE" # Options: "OPENAI", "GEMINI", "OLLAMA", "MISTRAL", or "NONE"
   ollamaServerUrl: "http://192.168.3.15:11434/api/generate"
   ollamaModelName: "mistral:7b"
   geminiModelName: "gemini-1.5-flash-latest"

--- a/templates/configmap-env.yaml
+++ b/templates/configmap-env.yaml
@@ -22,6 +22,8 @@ data:
   CLUSTER_ALGORITHM: {{ .Values.config.clusterAlgorithm | quote }}
   AI_MODEL_PROVIDER: {{ .Values.config.aiModelProvider | quote }}
   OLLAMA_MODEL_NAME: {{ .Values.config.ollamaModelName | quote }}
+  OPENAI_SERVER_URL: {{ .Values.config.openaiServerUrl | quote }}
+  OPENAI_MODEL_NAME: {{ .Values.config.openaiModelName | quote }}
   GEMINI_MODEL_NAME: {{ .Values.config.geminiModelName | quote }}
   MISTRAL_MODEL_NAME: {{ .Values.mistral.modelName | quote }}
   AI_CHAT_DB_USER_NAME: {{ .Values.config.aiChatDbUserName | quote }}

--- a/templates/flask.yaml
+++ b/templates/flask.yaml
@@ -70,6 +70,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "audiomuse-ai.fullname" . }}-mistral
                   key: MISTRAL_API_KEY
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "audiomuse-ai.fullname" . }}-openai
+                  key: OPENAI_API_KEY
             - name: AI_CHAT_DB_USER_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -51,6 +51,17 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ include "audiomuse-ai.fullname" . }}-openai
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "audiomuse-ai.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  OPENAI_API_KEY: {{ .Values.openai.apiKey | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: {{ include "audiomuse-ai.fullname" . }}-ai-chat-db
   namespace: {{ .Release.Namespace }} # Use .Release.Namespace
   labels:

--- a/templates/worker.yaml
+++ b/templates/worker.yaml
@@ -66,6 +66,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "audiomuse-ai.fullname" . }}-mistral
                   key: MISTRAL_API_KEY
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "audiomuse-ai.fullname" . }}-openai
+                  key: OPENAI_API_KEY
             - name: AI_CHAT_DB_USER_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -75,6 +75,9 @@ lyrion:
   password: "YOUR-PASSWORD"
   url: "http://YOUR-LYRION-URL"
 
+openai:
+  apiKey: "YOUR_OPENAI_API_KEY_HERE" # IMPORTANT: Change this for production or use --set
+
 gemini:
   apiKey: "YOUR_GEMINI_API_KEY_HERE" # IMPORTANT: Change this for production or use --set
 

--- a/values.yaml
+++ b/values.yaml
@@ -161,6 +161,8 @@ config:
   otherFeaturePredominanceThresholdForPurity: 0.3
   ollamaServerUrl: "http://192.168.3.15:11434/api/generate"
   ollamaModelName: "mistral:7b"
+  openaiServerUrl: "https://api.openai.com/v1/chat/completions"
+  openaiModelName: "gpt-5-mini"
   geminiModelName: "gemini-1.5-flash-latest"
   aiChatDbUserName: "ai_user"
   topNOtherFeatures: 2


### PR DESCRIPTION
Self-hosted AI solutions seem to strongly favour the OpenAI API spec rather than Ollama's API. With that in mind, this PR adds the three relevant environment variables to the helm chart.

`OPENAI_API_KEY` is another secret, included in the flask and worker pods. This isn't really relevant for self-hosting, but seems to be the best route through the AI code which uses the presence of an api-key to decide if we're using an OpenAI compatible API or an Ollama API.

`OPENAI_SERVER_URL` and `OPENAI_MODEL_NAME` are then regular environment variables.

Screenshot of my playlists generating locally with these changes and `qwen-30b-a3b-instruct`:
<img width="366" height="252" alt="Screenshot 2026-01-19 at 18 06 41" src="https://github.com/user-attachments/assets/1c949a86-eda4-40dd-a878-fb8c2b6b7203" />
