### PR TITLE
Bug Fix: Remove worker probes

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -10,7 +10,7 @@ namespace:
 
 image:
   repository: ghcr.io/neptunehub/audiomuse-ai
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart's appVersion.
   tag: ""
 
@@ -35,22 +35,8 @@ flask:
 
 worker:
   replicaCount: 1
-  livenessProbe:
-    exec:
-      command:
-        - python
-        - -c
-        - "import os, redis; redis.from_url(os.environ['REDIS_URL']).ping()"
-    initialDelaySeconds: 15
-    periodSeconds: 30
-  readinessProbe:
-    exec:
-      command:
-        - python
-        - -c
-        - "import os, redis; redis.from_url(os.environ['REDIS_URL']).ping()"
-    initialDelaySeconds: 5
-    periodSeconds: 15
+  # livenessProbe: {}
+  # readinessProbe: {}
   # nodeSelector: {}
 
 redis:


### PR DESCRIPTION
The worker probes did not work. I do not see any health endpoint to use for now.

Changes:

Container image configuration:

* Changed the `image.pullPolicy` from `Always` to `IfNotPresent` to avoid re-pulling the image if it already exists locally, which can improve deployment speed in some environments.

Worker probe configuration:

* Removed the explicit `livenessProbe` and `readinessProbe` configurations for the `worker` under `flask`, leaving them commented out and empty. This means the worker pods will no longer have custom health checks by default.